### PR TITLE
fetch-releases: add a tool to list the builds

### DIFF
--- a/installer/cmd/virtshift-fetch-releases/graph-20191202.json
+++ b/installer/cmd/virtshift-fetch-releases/graph-20191202.json
@@ -1,0 +1,1830 @@
+{
+  "nodes": [
+    {
+      "version": "4.2.9",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:f28cbabd1227352fe704a00df796a4511880174042dece96233036a10ac61639"
+    },
+    {
+      "version": "4.2.8",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:4bf307b98beba4d42da3316464013eac120c6e5a398646863ef92b0e2c621230"
+    },
+    {
+      "version": "4.2.7",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:bac62983757570b9b8f8bc84c740782984a255c16372b3e30cfc8b52c0a187b9"
+    },
+    {
+      "version": "4.2.6",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:a5d134c1a0709d5d9c7d6b476cbf613d6a8cd34c49591e0f9cd9b23cc14065a1"
+    },
+    {
+      "version": "4.2.5",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:37c3ebd6fcdd20820a575a3639891cf9feed65a7553129ac6f0d1ef57fc6ad1e"
+    },
+    {
+      "version": "4.2.4",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:cebce35c054f1fb066a4dc0a518064945087ac1f3637fe23d2ee2b0c433d6ba8"
+    },
+    {
+      "version": "4.2.2",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:dc782b44cac3d59101904cc5da2b9d8bdb90e55a07814df50ea7a13071b0f5f0"
+    },
+    {
+      "version": "4.2.1",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:32f2e138c0c5af6183830a22801f627bedb414591332960b7c8506ba7f6d7bb6"
+    },
+    {
+      "version": "4.2.0",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:c5337afd85b94c93ec513f21c8545e3f9e36a227f55d41bc1dfb8fcc3f2be129"
+    },
+    {
+      "version": "4.2.0-rc.5",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:1a2b56060f9d462ce879ce57d27f41941081ba063f4ac7f775505f0903d0713a"
+    },
+    {
+      "version": "4.2.0-rc.4",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:2ed0897c27fe0f2e27591da81f1f73c8cfefec6dfd4d3e67a68481d0efe38148"
+    },
+    {
+      "version": "4.2.0-rc.3",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:ab2241a765cb7715b7f5b5853b7b0bf8124e71459c5a80b74faf43ff51dcec49"
+    },
+    {
+      "version": "4.2.0-rc.2",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:9a1a38ce4d5fa79c785801eca3679a759bede9f40081b9e1b9f0cca2baa673a2"
+    },
+    {
+      "version": "4.2.0-rc.1",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:0a1dcbc81869f790fdd26d481706ee5d18ff4f5a13a833460d56fa0c396dc153"
+    },
+    {
+      "version": "4.2.0-rc.0",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:7e063c6b4a61377755284bf1a37bef8a25e5c1663a63fe2ba2e005f745f4e8c3"
+    },
+    {
+      "version": "4.1.26",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:3bc5f8bb2df578ea17e3d5ff5b9ae899a40fe16402b393abec0357f31eb85e58"
+    },
+    {
+      "version": "4.1.25",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:5f824fa3b3c44c6a78a5fc6a77a82edc47cf2b495bb6b2b31e3e0a4d3d77684b"
+    },
+    {
+      "version": "4.1.24",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:6f87fb66dfa907db03981e69474ea3069deab66358c18d965f6331bd727ff23f"
+    },
+    {
+      "version": "4.1.23",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:5dc1a2097ec0ecab4ef322c4e87bce93821c8ac9130a64ea3dc2f2bd8411a69c"
+    },
+    {
+      "version": "4.1.22",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:31d3c3f2f3d3f9b40d6fde943d71ef823af3b3ceb41ea4fbcd6f428082a28872"
+    },
+    {
+      "version": "4.1.21",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:a68066e534c41010b3750f18d620abede491965d5b0e860f5717b626cde08e5b"
+    },
+    {
+      "version": "4.1.20",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:a7e97365d16d8d920fedd3684b018b780337e069deb1dd8500e866c0d6110334"
+    },
+    {
+      "version": "4.1.19",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:56521ce8b07bddbb9e47452d6a2f3ebad0a3d3f120b9e70fdc589b5976f65fa5"
+    },
+    {
+      "version": "4.1.18",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:420633acf3fc7572372fe2df758152f6ab1f53a21c79a6c4b741fa0394c7df3a"
+    },
+    {
+      "version": "4.1.17",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:747e0d41ee2f1af8b234e8c96c3291225a120fab3af53ae691afb4f51ce02b85"
+    },
+    {
+      "version": "4.1.16",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:61ed953962d43cae388cb3c544b4cac358d4675076c2fc0befb236209d5116f7"
+    },
+    {
+      "version": "4.1.15",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:0a7f743a98e4d0937f44561138a03db8c09cdc4817a771a67f154e032435bcef"
+    },
+    {
+      "version": "4.1.14",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:fd41c9bda9e0ff306954f1fd7af6428edff8c3989b75f9fe984968db66846231"
+    },
+    {
+      "version": "4.1.13",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:212296a41e04176c308bfe169e7c6e05d77b76f403361664c3ce55cd30682a94"
+    },
+    {
+      "version": "4.1.12",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:c28afba66cc09233f7dfa49177423e124d939cf5b0cd60d71bbb918edb0ed739"
+    },
+    {
+      "version": "4.1.11",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:bfca31dbb518b35f312cc67516fa18aa40df9925dc84fdbcd15f8bbca425d7ff"
+    },
+    {
+      "version": "4.1.10",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:b2f03ea1b04edd25bf677aa755450eb0bb55898695b3ec1aa805ae2a97df3b90"
+    },
+    {
+      "version": "4.1.9",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:27fd24c705d1107cc73cb7dda8257fe97900e130b68afc314d0ef0e31bcf9b8e"
+    },
+    {
+      "version": "4.1.8",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:3ea2648231035c1a65e8d91fa818bb225a2815bc0d6abfc35063a11eaba8659f"
+    },
+    {
+      "version": "4.1.7",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:c9ce7c3b1e77d6cc5ee366364e4e0c6c901556aa3f61f7bd394b5e3010a1f551"
+    },
+    {
+      "version": "4.1.6",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:aa955a9ec40e55e5d9c0203a995b398e8c1031473dae24ed405efe9a95b43186"
+    },
+    {
+      "version": "4.1.4",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:a6c177eb007d20bb00bfd8f829e99bd40137167480112bd5ae1c25e40a4a163a"
+    },
+    {
+      "version": "4.1.3",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:f852f9d8c2e81a633e874e57a7d9bdd52588002a9b32fc037dba12b67cf1f8b0"
+    },
+    {
+      "version": "4.1.2",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:9c5f0df8b192a0d7b46cd5f6a4da2289c155fd5302dec7954f8f06c878160b8b"
+    },
+    {
+      "version": "4.1.1",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:e9415dbf80988553adc6c34740243805a21d92e3cdedeb2fd8d743ca56522a61"
+    },
+    {
+      "version": "4.1.0",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:b8307ac0f3ec4ac86c3f3b52846425205022da52c16f56ec31cbe428501001d6"
+    },
+    {
+      "version": "4.1.0-rc.9",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:49c4b6bf70061e522e3525aed534d087c9abfba7c39cbcbdd1bd770ab096bf9e"
+    },
+    {
+      "version": "4.1.0-rc.8",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:8250bbf79d4f567e24a7b85795aba97f9e75a9df18738891a0cb6ba42e422584"
+    },
+    {
+      "version": "4.1.0-rc.7",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:7e1e73c66702daa39223b3e6dd2cf5e15c057ef30c988256f55fae27448c3b01"
+    },
+    {
+      "version": "4.1.0-rc.6",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:1dabe42b5c94841fd8736d8f3a80afeaf5f5ad3833cef8d304c419a97b0efbc3"
+    },
+    {
+      "version": "4.1.0-rc.5",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:dc67ad5edd91ca48402309fe0629593e5ae3333435ef8d0bc52c2b62ca725021"
+    },
+    {
+      "version": "4.1.0-rc.4",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:6f4cf2db7e63c4dba54496a72b83fec22c49293b520ff0cdb78f1e38b23f1ccb"
+    },
+    {
+      "version": "4.1.0-rc.3",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:713aae8687cf8a3cb5c2c504f65532dfe11e1b3534448ea9eeef5b0931d3e208"
+    },
+    {
+      "version": "4.1.0-rc.2",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:689102dee32defd00a0803ccb206c604515f8f0198713e9c206d91fe295b4b63"
+    },
+    {
+      "version": "4.1.0-rc.1",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:be61a9ec132118e41a417b347242361d9cc96b1a73753e121dc7a74a1905baea"
+    },
+    {
+      "version": "4.1.0-rc.0",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:345ec9351ecc1d78c16cf0853fe0ef2d9f48dd493da5fdffc18fa18f45707867"
+    },
+    {
+      "version": "4.4.0-0.ci-2019-12-02-110229",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:d32118fce738d0b1631bf3ef4fce16d2b2dceebfdca8a37e286a734078b2bb59"
+    },
+    {
+      "version": "4.4.0-0.ci-2019-12-02-091221",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:3699b35e30af2164bdfe7cf3cee05ae2a4b52d61f46fade882b4a12cdf0812d5"
+    },
+    {
+      "version": "4.4.0-0.ci-2019-12-02-080047",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:317ec573e0be55d4e39c1502d6d1bd0da674888d024d281239899b8b74e88f66"
+    },
+    {
+      "version": "4.4.0-0.ci-2019-12-02-042359",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:e145da25f20cd222b3fefd11c77a26ad97eb8216f5253d3b0c7d4afe33491077"
+    },
+    {
+      "version": "4.4.0-0.ci-2019-12-01-001930",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:56248786e2e53cf31eeb0da2496bae7b9183d873d37d31960107ce555972993e"
+    },
+    {
+      "version": "4.4.0-0.ci-2019-11-30-142201",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:26a2ef13abdd4079a0e022569ae1228704f7fb321cb42777a7ed1181f8d93e89"
+    },
+    {
+      "version": "4.4.0-0.ci-2019-11-30-012856",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:fb1efca9eefe306e6df59469d1e9073b1e7442f4b24a7b13c49f47faf247be26"
+    },
+    {
+      "version": "4.4.0-0.ci-2019-11-29-205907",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:28c34a0d3f3cbcf738d3bf37c3cb9382a22e0022f8ea2b303157a643c67c0221"
+    },
+    {
+      "version": "4.4.0-0.ci-2019-11-29-202905",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:2f6e530135e2fd75c007299a87d22037bbb42e077e67824c7264c60922fd1c85"
+    },
+    {
+      "version": "4.4.0-0.ci-2019-11-29-100424",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:8ab43915af70f04890c9ae8b1aac57ea904d34f2b039a5202d0ca8b683d30f5e"
+    },
+    {
+      "version": "4.4.0-0.ci-2019-11-29-000859",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:e0432a414f70440035e700612b9b89f31719381c78bca38d1a4e0a56f9903349"
+    },
+    {
+      "version": "4.4.0-0.nightly-2019-12-02-052400",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:1b25c0c369d5a5c5cfc4bd770dbeb20da985b5bfb4aeb8a20c468b2cf0953e1a"
+    },
+    {
+      "version": "4.4.0-0.nightly-2019-11-29-143431",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:4fe0bea05f5c65bc571eb6d666f79d74a6e4b6407dd9d8f5d9a8a739ea5eb7da"
+    },
+    {
+      "version": "4.4.0-0.nightly-2019-11-29-093422",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:3f739a522a9cbb0a156813e74cca3394cdf3b948467d141fcda0d19af619e0bc"
+    },
+    {
+      "version": "4.4.0-0.nightly-2019-11-29-080420",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:d4afc02df0bca43568b76663670cb367270c23243855d96a5d9ef4b250174ebc"
+    },
+    {
+      "version": "4.4.0-0.nightly-2019-11-29-061146",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:9cdf8438796fd3e629dc86499105a668ba73bf8f7eeb9de7c5e77eb519d9c954"
+    },
+    {
+      "version": "4.4.0-0.nightly-2019-11-29-033906",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:cf719294488b39a2ff717868d0499449f37142a448f5554d4fe8761486af7a2b"
+    },
+    {
+      "version": "4.4.0-0.nightly-2019-11-29-003900",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:553f5360ecb4981052756c0e0a09801416b6a06077f5caa4b4523c355a6097ff"
+    },
+    {
+      "version": "4.4.0-0.nightly-2019-11-28-223858",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:ec1eaca7d42b68bb93ab9ed305b53fe57fc5b957010fe23b86a10a9ec8801beb"
+    },
+    {
+      "version": "4.4.0-0.nightly-2019-11-28-203856",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:2394f00ccfe0dc1391dc16580af3314ae80a51cda4ba5712ff693017d68152f1"
+    },
+    {
+      "version": "4.4.0-0.nightly-2019-11-28-143854",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:1f743fc406da0a85e3f1d627e2548d91501fe8a29ea3f98cff1479af86a336fd"
+    },
+    {
+      "version": "4.4.0-0.nightly-2019-11-28-100850",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:cdd171bab7e3ebde03d2197145aa1f33028319243103f5053e818f38ad166f7b"
+    },
+    {
+      "version": "4.4.0-0.nightly-2019-11-27-224549",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:206feefc00f97bf877e3f9f5bd745e00d4fd7c7bfe845538ce8de4a3be7b134c"
+    },
+    {
+      "version": "4.4.0-0.nightly-2019-11-27-095508",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:760659d688b2cd3b1d6422794cd31ed9e094c1c280194184d34e129e64e2ea6a"
+    },
+    {
+      "version": "4.4.0-0.nightly-2019-11-27-092506",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:4c62e6803272de934e34e6178eef07fe5bf3fc3184dc4d5f63e952fb14af2e0b"
+    },
+    {
+      "version": "4.4.0-0.nightly-2019-11-27-071027",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:1878ebbee442694ebf90aadd87d3519961864a34b8eca8f0cef90a7650a3475f"
+    },
+    {
+      "version": "4.4.0-0.nightly-2019-11-27-061107",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:301e5195856a4a47ebbe437676b003a133635fc48bb0faa2c7f43927e4375bf7"
+    },
+    {
+      "version": "4.4.0-0.nightly-2019-11-27-051103",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:2fc43a28021c9534f6e0fef04b89d8a1f7cd6efa81985b354137b3d4d449b732"
+    },
+    {
+      "version": "4.4.0-0.nightly-2019-11-27-044101",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:0752bafceefd020f11b5c92d9a3f7271c9d35120f0b0e9facbb42dc3ba7515af"
+    },
+    {
+      "version": "4.4.0-0.nightly-2019-11-27-031058",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:3bf6a3ed13f25e4ed07102653dd4067c60537b3ad4548b06ededaf8d2f687a93"
+    },
+    {
+      "version": "4.4.0-0.nightly-2019-11-26-065459",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:0ebef15942b6a059f2379b7fb5c6900d9a05d9b6a7a95b85f6a6c1ddb369e355"
+    },
+    {
+      "version": "4.4.0-0.nightly-2019-11-26-041012",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:05c465dadb8530185cc5d4740682a41073e50b7079fb4bb48d5bcc9059b6d5c4"
+    },
+    {
+      "version": "4.4.0-0.nightly-2019-11-25-223939",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:0ebe735a5a4c78bb12cd63e04897c1247b9bcf9f1d777748151bf88c96574ed1"
+    },
+    {
+      "version": "4.4.0-0.nightly-2019-11-25-183933",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:c68c4fa3eb97cd9a21cdff6724fcd3b2da754521dcb2cff5295043e97ab13f11"
+    },
+    {
+      "version": "4.4.0-0.nightly-2019-11-25-163930",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:9e8440c37cbf6d0aea71573dc370451e59ca4d2fb3ca6e53df72d7d44a3baa72"
+    },
+    {
+      "version": "4.3.0-0.nightly-2019-12-02-055401",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:ca55c9894311071526e192468a8aefacb92367c2da3ebbaac29d548a0a1ad2b6"
+    },
+    {
+      "version": "4.3.0-0.nightly-2019-11-29-130430",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:f1a7c04ddf0c3773c97d805ba270d3cabbf8fd17a0307966f83f7c783e17e0c7"
+    },
+    {
+      "version": "4.3.0-0.nightly-2019-11-29-073419",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:6e85b342901e332daa59e67808229832b36197f5e228919992d461d5746f04b1"
+    },
+    {
+      "version": "4.3.0-0.nightly-2019-11-29-051144",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:c0d823f4424a7e8298e4a823f28ed967cd88d86988fe4cfd7d68ae3579946aa6"
+    },
+    {
+      "version": "4.3.0-0.nightly-2019-11-29-040907",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:8416cbb0858cac607d1e4edf0b728e3b225d1de3ea420c0d322cb2f3b8018298"
+    },
+    {
+      "version": "4.3.0-0.nightly-2019-11-29-013902",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:a1d2e148345b145a1af5a34b08f0ed3fedbb4e983651d243310bfc1c5ff79c79"
+    },
+    {
+      "version": "4.3.0-0.nightly-2019-11-28-233859",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:4019f2819ca6a07f41dd059e7bd444e5ef127fc1704e3c7f1d7487c48c3372c2"
+    },
+    {
+      "version": "4.3.0-0.nightly-2019-11-28-190856",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:1551fd223e60908933fdc0fe15c99b87c601e3d54fa033fb36292d6fc5580955"
+    },
+    {
+      "version": "4.3.0-0.nightly-2019-11-28-153854",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:e0900d4a807163a2d05d785ace3a00eccc57cde82a445b87daead11cb2d500b7"
+    },
+    {
+      "version": "4.3.0-0.nightly-2019-11-28-103851",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:4d4e252272b224ac8566d76762bef7ef691127f4cad29d4dcfaebb1e94ab9cda"
+    },
+    {
+      "version": "4.3.0-0.nightly-2019-11-28-080846",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:6f3727666184f92edd54f212a5f1b87948954d14e5da286bc99f63ac130ab07b"
+    },
+    {
+      "version": "4.3.0-0.nightly-2019-11-28-053411",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:454fca9574e7829fdc64e147c8cfb5370dc88aa8eabfdbdbf003bcce11521c32"
+    },
+    {
+      "version": "4.3.0-0.nightly-2019-11-28-035756",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:91b6444db8cbd03fa6027637cf55eae8f662269b0e7f6e9cc8e66dd899dbf152"
+    },
+    {
+      "version": "4.3.0-0.nightly-2019-11-28-004553",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:38f4df0f99b6a2f4b533abc1271583c112159f15e08227be4b7ff87c9be1af3a"
+    },
+    {
+      "version": "4.3.0-0.nightly-2019-11-27-231550",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:a52b73d12d0ceab7bbc7d480f85d6758f637470d62e5e9b05cd4314beb97cd0f"
+    },
+    {
+      "version": "4.3.0-0.nightly-2019-11-27-201544",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:9fc0e0308fa1d66bdbbb3418ef0c92d4ac99b3fb35504021e5124f8dc23d2f2b"
+    },
+    {
+      "version": "4.3.0-0.nightly-2019-11-27-125722",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:f45416bdc036751b07a8522e632116444f263660da047785cb6009862d7f4d9e"
+    },
+    {
+      "version": "4.3.0-0.nightly-2019-11-27-082504",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:c4e96103c39f5391ff4f36ba07d1f3ecf287d5590c38ddc812b96dbad5ad1999"
+    },
+    {
+      "version": "4.3.0-0.nightly-2019-11-27-041100",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:747c3060f0dd0463ee8a09a22fa68b8014e021292cfcb69eff52a0e2caeca40e"
+    },
+    {
+      "version": "4.3.0-0.nightly-2019-11-27-011055",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:d70b3b24822101c07306718b3b33be3ec75a3853a7aadf0208ee76610e191f69"
+    },
+    {
+      "version": "4.3.0-0.nightly-2019-11-26-171052",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:b68e7444baef46e79e64101bbb58bc02a30f4ccb647a1aaaf5712397f718f0dd"
+    },
+    {
+      "version": "4.3.0-0.nightly-2019-11-25-153929",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:9e31c2b86ef648d5aaa18387b88dce1365383b00879bce6ef3c72603ea277727"
+    },
+    {
+      "version": "4.2.0-0.ci-2019-11-30-132200",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:7d8f331f30e1962da17a1ed8868389d3e0b98bf197d75898be10a126e36d5844"
+    },
+    {
+      "version": "4.2.0-0.ci-2019-11-29-140430",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:03788b0cd33ae3a0ea39a33d706e6688810ea302962c45e30fba9127c1be3608"
+    },
+    {
+      "version": "4.2.0-0.ci-2019-11-28-173854",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:bd5c0e57e866cc019161006854449de6a4b8a66d8a2374c3fc209edb5888fee8"
+    },
+    {
+      "version": "4.2.0-0.ci-2019-11-28-130854",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:10f3e630823680316d6e6e66eead5bc937550f28427cce896c15891e37751d1a"
+    },
+    {
+      "version": "4.2.0-0.ci-2019-11-27-234550",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:ecbd99542309ef4f576076c9fa8e18093a9e7b60b7037b4b3c04ec14ff6ce685"
+    },
+    {
+      "version": "4.2.0-0.ci-2019-11-27-132722",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:630512d0b37620682be7ccf92ab3efe42c1b849ae55f4688f2f940c108a6b7f0"
+    },
+    {
+      "version": "4.2.0-0.ci-2019-08-21-102306",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:cf9f3e52f9ccf6f8e3a5a35653bbf853058a6d143b8ab728878b9265006dd0b1"
+    },
+    {
+      "version": "4.2.0-0.ci-2019-07-31-123929",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:23a49ba80628a77aaca09822ae65a16caca609bb607fce17757a801ad49b559e"
+    },
+    {
+      "version": "4.2.0-0.ci-2019-07-22-025130",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:12da30aa8d94d8d4d4db3f8c88a30b6bdaf847bc714b2a551a2637a89c36f3c1"
+    },
+    {
+      "version": "4.2.0-0.ci-2019-05-21-145642",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:164425f87634569ec06b8a2b3da7b2952453b7953cc6cd2b9bbfc633a4cb3573"
+    },
+    {
+      "version": "4.1.0-0.ci-2019-11-28-200856",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:4a67ae3cd45d3ea6ac30315c7ec3709eeb4be56f7e0a60398976e7144afe0822"
+    },
+    {
+      "version": "4.1.0-0.ci-2019-11-28-140854",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:b6dfef2b68c10b84250b526f4daca9df65574f91811dde383fb119423bebc042"
+    },
+    {
+      "version": "4.1.0-0.ci-2019-11-28-133854",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:bf92f66b2bc4e993b685e5f2eb759bde196352f5a1d1bd0352e4849471f80db3"
+    },
+    {
+      "version": "4.1.0-0.ci-2019-11-26-181052",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:118a3d448523822fd2dad09a76081b0af4fa92b2d1aedd0b53d771111d49c4ed"
+    },
+    {
+      "version": "4.1.0-0.ci-2019-11-26-141052",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:dc3a19bfe9135d67b8e6aefb387d60804651da66e533545981a5a2e034e0e876"
+    },
+    {
+      "version": "4.1.0-0.ci-2019-11-26-101052",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:ea5f0fcb25848d24a4d5050e1e7f3fdb642a1de92f40e67bc01e0cdbcfc63bc4"
+    },
+    {
+      "version": "4.1.0-0.ci-2019-11-21-162907",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:d36ca7ce03ff4ee9248c01ea1fa922c8228609df3817fb373cc52a713343b578"
+    },
+    {
+      "version": "4.1.0-0.ci-2019-04-27-141901",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:90de2c8e6bde7b252141803dc97a5aa125ac0c0464c8f337a76819034a2454cb"
+    },
+    {
+      "version": "4.1.0-0.ci-2019-04-27-130002",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:3103c6af1a0168e604841851d622f26df54effff7bba1a37eb435139f58f11c8"
+    },
+    {
+      "version": "4.3.0-0.ci-2019-12-02-045359",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:0451f3edfe0fa8003883898113fe1e18ecb214e36033f7c71337517ed81fb4f7"
+    },
+    {
+      "version": "4.3.0-0.ci-2019-11-30-234318",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:312d7950e0d4df073f615306b30456f6ee943aad034f2f5da48fc46dde9d4712"
+    },
+    {
+      "version": "4.3.0-0.ci-2019-11-30-222207",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:23107f96bd3182568c5883ec5d925f8653032813244f2e2fa223812e239df104"
+    },
+    {
+      "version": "4.3.0-0.ci-2019-11-30-190034",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:f69130b784be09a2c7c7f625fad15fa285967c311a976da873edc8926c29fa26"
+    },
+    {
+      "version": "4.3.0-0.ci-2019-11-30-170135",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:84faf68f5da1b17e9ee98687c839a1e3def1a92bb30d47d617b29716966c073e"
+    },
+    {
+      "version": "4.3.0-0.ci-2019-11-22-122829",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:96fd9e83f5ed63a045e7a9432d89566ca802a309c07c60061561903348949c88"
+    },
+    {
+      "version": "4.3.0-0.ci-2019-11-21-195648",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:9aa0dd4a4af3f766e8d5b3dbc15f4c1f7a9c670732565ae193523bb2132c31a9"
+    },
+    {
+      "version": "4.3.0-0.ci-2019-11-21-175142",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:6b0fec3fcb5c094fadc9d312d17214e52be2b34d9726ce8af1ddbc0627f82f4e"
+    },
+    {
+      "version": "4.3.0-0.ci-2019-11-21-103638",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:37daa3c9717d95aae1eae8c210cfd5f18722347af7478aeb52501b651572d89a"
+    },
+    {
+      "version": "4.3.0-0.ci-2019-11-21-023035",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:2d586b113c094e481a6664a754c7e720b141eccf6ad12e1201a8735e04779306"
+    },
+    {
+      "version": "4.1.0-0.nightly-2019-11-29-120430",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:5f1b2b863125f31c5ff8669ac5bfb6fc592602d157d1d686d1f18a86d6116476"
+    },
+    {
+      "version": "4.1.0-0.nightly-2019-11-28-220857",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:98a84963a150a2e02f3c97e8a033510437b8c9a56df0a9e25eddc8cb3e487edb"
+    },
+    {
+      "version": "4.1.0-0.nightly-2019-11-28-163854",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:bdc8530aaadcd89257191c087f560c84c1e34ecbf0c65bc4d8dc8353b8c75587"
+    },
+    {
+      "version": "4.1.0-0.nightly-2019-11-26-194052",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:faa5ac20a0067a9c790f1700f791b5d480111e11b3d575d8c7c6a1df2ccd8c50"
+    },
+    {
+      "version": "4.1.0-0.nightly-2019-11-26-154052",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:7bbcf0edf7a7de60b4c7281b7376abf40c2cd275380d0de406b400846d951e45"
+    },
+    {
+      "version": "4.1.0-0.nightly-2019-11-26-104052",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:5f8714a234275545d09382742cc5590a6efeaa4fbc00b316952a9d0bcccc9341"
+    },
+    {
+      "version": "4.1.0-0.nightly-2019-07-18-192922",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:bd4416f13b6f41a0e5005bc6b26517ce2ae54b583b42d5b3dbb31dc0aa49ff54"
+    },
+    {
+      "version": "4.1.0-0.nightly-2019-07-12-180931",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:31fd4d4ce439154f226530c29e033ff2f6af3b2ef838567ef687e42cfae72a7a"
+    },
+    {
+      "version": "4.1.0-0.nightly-2019-05-05-070156",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:ba7f8c21376cbcbc1c097c266a69ba37456253e581a0b9bcd3efd3d82fbe37d6"
+    },
+    {
+      "version": "4.1.0-0.nightly-2019-04-22-192604",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:c1ee8396785e975e0d84c9000dcb4bd55c8c3564bbbf094ee17e024653ab3193"
+    },
+    {
+      "version": "4.1.0-0.nightly-2019-04-22-005054",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:3f3628cd9b694705cb0627ce72e61932df5d9938a291fabba1ed691230f7b548"
+    },
+    {
+      "version": "4.2.0-0.nightly-2019-11-28-230858",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:be488894d4158095c3d0ecb69a29995c9ab459d295d13a0433ae90b921efc316"
+    },
+    {
+      "version": "4.2.0-0.nightly-2019-11-28-180854",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:0a6b6d9e301fa2e70a9e2c8a9c923de3bb61bab367a5657b3c763b148b6f8243"
+    },
+    {
+      "version": "4.2.0-0.nightly-2019-11-27-102509",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:c3f94a2c2b3e3b0ff346ef02fec9dac9439a88bb8bfbb7bd239fdf331a9b1ad0"
+    },
+    {
+      "version": "4.2.0-0.nightly-2019-11-27-004055",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:b474fe296069e2d79098bd4000de6db45d0e0b1f2299afd94524974779b4e271"
+    },
+    {
+      "version": "4.2.0-0.nightly-2019-11-26-164052",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:1def866a3088c961a271d781c2d5561c300bf2a8ba02a6c0f65644dc19290567"
+    },
+    {
+      "version": "4.2.0-0.nightly-2019-11-26-111052",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:b856f1f25d125e37e9c0f4d3601b6077be9ad3fabe7a4276dc51db0a3939cef6"
+    },
+    {
+      "version": "4.2.0-0.nightly-2019-11-25-200935",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:11a50d6742a70d62f4d14d9abc0ffab50748d9463b40a2491baaaf805764c4b5"
+    },
+    {
+      "version": "4.2.0-0.nightly-2019-11-25-170932",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:d0df592731ca0a2156f445c2b4ec349622964663b7302678a9a50a014bd10712"
+    },
+    {
+      "version": "4.2.0-0.nightly-2019-11-25-150929",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:ba1428b756d57db161773f08be3d6efd1382713611519baf5cf7cebfeba3b6a2"
+    },
+    {
+      "version": "4.2.0-0.nightly-2019-11-25-111442",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:6197de68fdf6084dbeeece35475fe28139bc966e4f5fdd52a82e9acd66d7c476"
+    },
+    {
+      "version": "4.2.0-0.nightly-2019-09-04-102339",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:a1c2c85e773ab8edf54d8b136b003cf99fde10d32ea4fb51fa859daacc6163e5"
+    },
+    {
+      "version": "4.2.0-0.nightly-2019-08-20-213632",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:3221bdaf2797bcfea873ae18e377253b14f0bc301b0640a26c6ddbc0ed9a4a06"
+    },
+    {
+      "version": "4.2.0-0.nightly-2019-08-20-162755",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:d0bc8d66b0ed4d5b4f2da5a1fb93e0589b88c5fcf94763bb8b56b0f022b3f51d"
+    },
+    {
+      "version": "4.2.0-0.nightly-2019-07-12-041904",
+      "payload": "registry.svc.ci.openshift.org/ocp/release@sha256:5d454fcad5416f5c7ff75c6730508649f312109357a589a973d04c055e0fbda6"
+    }
+  ],
+  "edges": [
+    [
+      104,
+      103
+    ],
+    [
+      140,
+      139
+    ],
+    [
+      23,
+      14
+    ],
+    [
+      160,
+      159
+    ],
+    [
+      30,
+      26
+    ],
+    [
+      27,
+      26
+    ],
+    [
+      33,
+      26
+    ],
+    [
+      36,
+      26
+    ],
+    [
+      35,
+      26
+    ],
+    [
+      34,
+      26
+    ],
+    [
+      32,
+      26
+    ],
+    [
+      28,
+      26
+    ],
+    [
+      25,
+      26
+    ],
+    [
+      38,
+      26
+    ],
+    [
+      37,
+      26
+    ],
+    [
+      147,
+      146
+    ],
+    [
+      83,
+      82
+    ],
+    [
+      32,
+      31
+    ],
+    [
+      39,
+      31
+    ],
+    [
+      37,
+      31
+    ],
+    [
+      36,
+      31
+    ],
+    [
+      35,
+      31
+    ],
+    [
+      34,
+      31
+    ],
+    [
+      33,
+      31
+    ],
+    [
+      16,
+      113
+    ],
+    [
+      99,
+      98
+    ],
+    [
+      48,
+      47
+    ],
+    [
+      32,
+      28
+    ],
+    [
+      30,
+      28
+    ],
+    [
+      27,
+      28
+    ],
+    [
+      38,
+      28
+    ],
+    [
+      35,
+      28
+    ],
+    [
+      34,
+      28
+    ],
+    [
+      33,
+      28
+    ],
+    [
+      29,
+      28
+    ],
+    [
+      36,
+      28
+    ],
+    [
+      35,
+      36
+    ],
+    [
+      40,
+      36
+    ],
+    [
+      39,
+      36
+    ],
+    [
+      37,
+      36
+    ],
+    [
+      132,
+      130
+    ],
+    [
+      16,
+      154
+    ],
+    [
+      1,
+      154
+    ],
+    [
+      157,
+      155
+    ],
+    [
+      16,
+      155
+    ],
+    [
+      132,
+      131
+    ],
+    [
+      101,
+      100
+    ],
+    [
+      95,
+      93
+    ],
+    [
+      139,
+      138
+    ],
+    [
+      15,
+      138
+    ],
+    [
+      0,
+      150
+    ],
+    [
+      16,
+      150
+    ],
+    [
+      152,
+      150
+    ],
+    [
+      5,
+      4
+    ],
+    [
+      17,
+      4
+    ],
+    [
+      2,
+      136
+    ],
+    [
+      15,
+      140
+    ],
+    [
+      141,
+      140
+    ],
+    [
+      16,
+      140
+    ],
+    [
+      58,
+      57
+    ],
+    [
+      46,
+      45
+    ],
+    [
+      46,
+      44
+    ],
+    [
+      45,
+      44
+    ],
+    [
+      16,
+      0
+    ],
+    [
+      1,
+      0
+    ],
+    [
+      126,
+      125
+    ],
+    [
+      17,
+      1
+    ],
+    [
+      2,
+      1
+    ],
+    [
+      89,
+      87
+    ],
+    [
+      71,
+      68
+    ],
+    [
+      102,
+      101
+    ],
+    [
+      77,
+      74
+    ],
+    [
+      119,
+      118
+    ],
+    [
+      16,
+      15
+    ],
+    [
+      17,
+      15
+    ],
+    [
+      40,
+      39
+    ],
+    [
+      17,
+      3
+    ],
+    [
+      4,
+      3
+    ],
+    [
+      9,
+      8
+    ],
+    [
+      21,
+      8
+    ],
+    [
+      106,
+      104
+    ],
+    [
+      20,
+      19
+    ],
+    [
+      2,
+      135
+    ],
+    [
+      1,
+      135
+    ],
+    [
+      136,
+      135
+    ],
+    [
+      121,
+      120
+    ],
+    [
+      31,
+      30
+    ],
+    [
+      28,
+      30
+    ],
+    [
+      32,
+      30
+    ],
+    [
+      112,
+      110
+    ],
+    [
+      15,
+      110
+    ],
+    [
+      66,
+      64
+    ],
+    [
+      55,
+      54
+    ],
+    [
+      61,
+      60
+    ],
+    [
+      33,
+      25
+    ],
+    [
+      32,
+      25
+    ],
+    [
+      28,
+      25
+    ],
+    [
+      27,
+      25
+    ],
+    [
+      35,
+      25
+    ],
+    [
+      34,
+      25
+    ],
+    [
+      36,
+      25
+    ],
+    [
+      30,
+      25
+    ],
+    [
+      26,
+      25
+    ],
+    [
+      24,
+      25
+    ],
+    [
+      37,
+      25
+    ],
+    [
+      110,
+      109
+    ],
+    [
+      15,
+      109
+    ],
+    [
+      27,
+      23
+    ],
+    [
+      26,
+      23
+    ],
+    [
+      36,
+      23
+    ],
+    [
+      30,
+      23
+    ],
+    [
+      24,
+      23
+    ],
+    [
+      35,
+      23
+    ],
+    [
+      34,
+      23
+    ],
+    [
+      33,
+      23
+    ],
+    [
+      32,
+      23
+    ],
+    [
+      28,
+      23
+    ],
+    [
+      25,
+      23
+    ],
+    [
+      32,
+      33
+    ],
+    [
+      34,
+      33
+    ],
+    [
+      30,
+      21
+    ],
+    [
+      26,
+      21
+    ],
+    [
+      25,
+      21
+    ],
+    [
+      33,
+      21
+    ],
+    [
+      28,
+      21
+    ],
+    [
+      27,
+      21
+    ],
+    [
+      24,
+      21
+    ],
+    [
+      23,
+      21
+    ],
+    [
+      34,
+      21
+    ],
+    [
+      32,
+      21
+    ],
+    [
+      60,
+      58
+    ],
+    [
+      21,
+      20
+    ],
+    [
+      132,
+      129
+    ],
+    [
+      1,
+      134
+    ],
+    [
+      135,
+      134
+    ],
+    [
+      97,
+      95
+    ],
+    [
+      124,
+      121
+    ],
+    [
+      66,
+      62
+    ],
+    [
+      84,
+      83
+    ],
+    [
+      34,
+      32
+    ],
+    [
+      33,
+      32
+    ],
+    [
+      40,
+      32
+    ],
+    [
+      30,
+      32
+    ],
+    [
+      37,
+      32
+    ],
+    [
+      36,
+      32
+    ],
+    [
+      35,
+      32
+    ],
+    [
+      0,
+      132
+    ],
+    [
+      1,
+      132
+    ],
+    [
+      133,
+      132
+    ],
+    [
+      121,
+      119
+    ],
+    [
+      23,
+      11
+    ],
+    [
+      14,
+      11
+    ],
+    [
+      13,
+      11
+    ],
+    [
+      12,
+      11
+    ],
+    [
+      46,
+      42
+    ],
+    [
+      43,
+      42
+    ],
+    [
+      8,
+      7
+    ],
+    [
+      21,
+      7
+    ],
+    [
+      20,
+      7
+    ],
+    [
+      23,
+      12
+    ],
+    [
+      14,
+      12
+    ],
+    [
+      13,
+      12
+    ],
+    [
+      35,
+      143
+    ],
+    [
+      34,
+      143
+    ],
+    [
+      16,
+      153
+    ],
+    [
+      154,
+      153
+    ],
+    [
+      40,
+      29
+    ],
+    [
+      39,
+      29
+    ],
+    [
+      30,
+      29
+    ],
+    [
+      37,
+      29
+    ],
+    [
+      36,
+      29
+    ],
+    [
+      16,
+      151
+    ],
+    [
+      152,
+      151
+    ],
+    [
+      80,
+      76
+    ],
+    [
+      132,
+      127
+    ],
+    [
+      71,
+      70
+    ],
+    [
+      73,
+      72
+    ],
+    [
+      60,
+      59
+    ],
+    [
+      32,
+      27
+    ],
+    [
+      40,
+      27
+    ],
+    [
+      39,
+      27
+    ],
+    [
+      28,
+      27
+    ],
+    [
+      26,
+      27
+    ],
+    [
+      36,
+      27
+    ],
+    [
+      35,
+      27
+    ],
+    [
+      33,
+      27
+    ],
+    [
+      31,
+      27
+    ],
+    [
+      30,
+      27
+    ],
+    [
+      38,
+      27
+    ],
+    [
+      37,
+      27
+    ],
+    [
+      34,
+      27
+    ],
+    [
+      124,
+      122
+    ],
+    [
+      55,
+      53
+    ],
+    [
+      42,
+      40
+    ],
+    [
+      41,
+      40
+    ],
+    [
+      46,
+      40
+    ],
+    [
+      77,
+      75
+    ],
+    [
+      28,
+      24
+    ],
+    [
+      37,
+      24
+    ],
+    [
+      36,
+      24
+    ],
+    [
+      35,
+      24
+    ],
+    [
+      34,
+      24
+    ],
+    [
+      33,
+      24
+    ],
+    [
+      30,
+      24
+    ],
+    [
+      27,
+      24
+    ],
+    [
+      26,
+      24
+    ],
+    [
+      25,
+      24
+    ],
+    [
+      23,
+      24
+    ],
+    [
+      32,
+      24
+    ],
+    [
+      37,
+      35
+    ],
+    [
+      36,
+      35
+    ],
+    [
+      34,
+      35
+    ],
+    [
+      40,
+      35
+    ],
+    [
+      39,
+      35
+    ],
+    [
+      38,
+      35
+    ],
+    [
+      157,
+      156
+    ],
+    [
+      18,
+      17
+    ],
+    [
+      93,
+      92
+    ],
+    [
+      150,
+      148
+    ],
+    [
+      15,
+      148
+    ],
+    [
+      67,
+      66
+    ],
+    [
+      81,
+      79
+    ],
+    [
+      132,
+      128
+    ],
+    [
+      91,
+      89
+    ],
+    [
+      17,
+      16
+    ],
+    [
+      46,
+      41
+    ],
+    [
+      45,
+      41
+    ],
+    [
+      44,
+      41
+    ],
+    [
+      43,
+      41
+    ],
+    [
+      42,
+      41
+    ],
+    [
+      34,
+      116
+    ],
+    [
+      46,
+      43
+    ],
+    [
+      44,
+      43
+    ],
+    [
+      58,
+      56
+    ],
+    [
+      138,
+      137
+    ],
+    [
+      15,
+      108
+    ],
+    [
+      109,
+      108
+    ],
+    [
+      23,
+      22
+    ],
+    [
+      27,
+      22
+    ],
+    [
+      25,
+      22
+    ],
+    [
+      24,
+      22
+    ],
+    [
+      40,
+      38
+    ],
+    [
+      39,
+      38
+    ],
+    [
+      103,
+      102
+    ],
+    [
+      40,
+      37
+    ],
+    [
+      38,
+      37
+    ],
+    [
+      66,
+      63
+    ],
+    [
+      23,
+      10
+    ],
+    [
+      11,
+      10
+    ],
+    [
+      106,
+      105
+    ],
+    [
+      19,
+      18
+    ],
+    [
+      6,
+      5
+    ],
+    [
+      19,
+      5
+    ],
+    [
+      18,
+      5
+    ],
+    [
+      16,
+      152
+    ],
+    [
+      153,
+      152
+    ],
+    [
+      1,
+      152
+    ],
+    [
+      23,
+      13
+    ],
+    [
+      14,
+      13
+    ],
+    [
+      99,
+      97
+    ],
+    [
+      16,
+      157
+    ],
+    [
+      71,
+      69
+    ],
+    [
+      1,
+      107
+    ],
+    [
+      91,
+      90
+    ],
+    [
+      67,
+      65
+    ],
+    [
+      20,
+      6
+    ],
+    [
+      7,
+      6
+    ],
+    [
+      35,
+      34
+    ],
+    [
+      40,
+      34
+    ],
+    [
+      38,
+      34
+    ],
+    [
+      37,
+      34
+    ],
+    [
+      36,
+      34
+    ],
+    [
+      89,
+      86
+    ],
+    [
+      74,
+      73
+    ],
+    [
+      81,
+      78
+    ],
+    [
+      16,
+      112
+    ],
+    [
+      15,
+      112
+    ],
+    [
+      113,
+      112
+    ],
+    [
+      142,
+      141
+    ],
+    [
+      101,
+      99
+    ],
+    [
+      95,
+      94
+    ],
+    [
+      107,
+      106
+    ],
+    [
+      11,
+      9
+    ],
+    [
+      10,
+      9
+    ],
+    [
+      23,
+      9
+    ],
+    [
+      21,
+      9
+    ],
+    [
+      15,
+      111
+    ],
+    [
+      112,
+      111
+    ],
+    [
+      83,
+      81
+    ],
+    [
+      17,
+      2
+    ],
+    [
+      3,
+      2
+    ],
+    [
+      90,
+      88
+    ],
+    [
+      134,
+      133
+    ],
+    [
+      1,
+      133
+    ]
+  ]
+}

--- a/installer/cmd/virtshift-fetch-releases/main.go
+++ b/installer/cmd/virtshift-fetch-releases/main.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"text/tabwriter"
+	"text/template"
+
+	"github.com/spf13/pflag"
+
+	"github.com/fromanirh/virtshift/installer/pkg/graphinfo"
+)
+
+const (
+	helpMessage = `{{ .Executable }} fetches the last builds from OCP CI.
+
+Usage: {{ .Executable }} [flags]
+
+Environment variables:
+VIRTSHIFT_DEBUG: set this variable (any value) to enable debug messages (disabled)
+
+`
+	// ref: https://github.com/openshift/cincinnati
+	defaultGraphURL   = "https://openshift-release.svc.ci.openshift.org/graph"
+	defaultOCPVersion = "4.3"
+)
+
+func showHelp() {
+	type Help struct {
+		Executable string
+	}
+	help := Help{
+		Executable: "virtshift-fetch-releases",
+	}
+	tmpl := template.Must(template.New("help").Parse(helpMessage))
+	err := tmpl.Execute(os.Stderr, help)
+	if err != nil {
+		panic(err)
+	}
+	pflag.PrintDefaults()
+}
+
+func main() {
+	var graphURL string
+	var OCPVersion string
+
+	pflag.Usage = showHelp
+	pflag.StringVarP(&graphURL, "url", "u", defaultGraphURL, "URL from where to get the graph data")
+	pflag.StringVarP(&OCPVersion, "ocpversion", "V", defaultOCPVersion, "OCP version to be considered")
+	pflag.Parse()
+
+	bi, err := graphinfo.NewFromURL(graphURL, OCPVersion)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		os.Exit(1)
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 2, 1, ' ', 0)
+	for _, item := range bi {
+		fmt.Fprintf(w, "%s\t\t%s\n", item.Version, item.Payload)
+	}
+	w.Flush()
+}

--- a/installer/pkg/graphinfo/graphinfo.go
+++ b/installer/pkg/graphinfo/graphinfo.go
@@ -1,0 +1,85 @@
+package graphinfo
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/fromanirh/virtshift/installer/pkg/debug"
+)
+
+type BuildInfo struct {
+	Version string `json:"version"`
+	Payload string `json:"payload"`
+}
+
+type Edge [2]int
+
+type Graph struct {
+	Edges []Edge      `json:"edges"`
+	Nodes []BuildInfo `json:"nodes"`
+}
+
+func NewFromURL(location, version string) ([]BuildInfo, error) {
+	u, err := url.Parse(location)
+	if err != nil {
+		return nil, err
+	}
+	var allInfos []BuildInfo
+	if u.Scheme == "" {
+		// assume local path
+		allInfos, err = newFromFile(u.Path)
+	} else {
+		allInfos, err = newFromHTTP(location)
+	}
+	if err != nil {
+		return nil, err
+	}
+	versionInfos := takeByVersion(allInfos, version)
+	// TODO: sort
+	return versionInfos, nil
+}
+
+func newFromFile(path string) ([]BuildInfo, error) {
+	debug.Printf("reading buildinfos from file: %s", path)
+	fd, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer fd.Close()
+	return extractBuildInfoFromGraphJSON(fd)
+}
+
+func newFromHTTP(location string) ([]BuildInfo, error) {
+	debug.Printf("reading buildinfos from http: %s", location)
+	resp, err := http.Get(location)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	return extractBuildInfoFromGraphJSON(resp.Body)
+}
+
+func extractBuildInfoFromGraphJSON(r io.Reader) ([]BuildInfo, error) {
+	debug.Printf("parsing graphinfos")
+	g := Graph{}
+	dec := json.NewDecoder(r)
+	err := dec.Decode(&g)
+	if err != nil {
+		return nil, err
+	}
+	return g.Nodes, nil
+}
+
+func takeByVersion(bi []BuildInfo, version string) []BuildInfo {
+	res := []BuildInfo{}
+	for _, item := range bi {
+		if strings.HasPrefix(item.Version, version) {
+			res = append(res, item)
+		}
+	}
+	return res
+}


### PR DESCRIPTION
The idea is to have all the info in one place
instead of cross-correlating few web pages.

Signed-off-by: Francesco Romani <fromani@redhat.com>